### PR TITLE
Affichage vertical des semaines

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,10 +116,10 @@ const server = http.createServer((req, res) => {
         }
 
         .board {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+          display: flex;
+          flex-direction: column;
           gap: 1.5rem;
-          align-items: stretch;
+          width: 100%;
         }
 
         .week-column {
@@ -453,7 +453,7 @@ const server = http.createServer((req, res) => {
 
         @media (max-width: 600px) {
           .board {
-            grid-template-columns: 1fr;
+            gap: 1rem;
           }
 
           .app-header {


### PR DESCRIPTION
## Summary
- afficher les semaines les unes sous les autres en remplaçant la grille par une pile verticale
- ajuster l'espacement sur mobile pour conserver un rendu harmonieux

## Testing
- npm run start


------
https://chatgpt.com/codex/tasks/task_b_68d3ce7bea88832180bcb9b171f0a051