### PR TITLE
Réduit la hauteur des activités en vue semaine

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ const server = http.createServer((req, res) => {
         .slot-activities {
           display: flex;
           flex-direction: column;
-          gap: 1rem;
+          gap: 0.75rem;
           min-height: 52px;
           padding: 0.25rem;
           border-radius: var(--radius-md);
@@ -253,11 +253,15 @@ const server = http.createServer((req, res) => {
         .activity-card {
           background: linear-gradient(180deg, rgba(243, 249, 255, 0.95), rgba(226, 240, 255, 0.95));
           border-radius: var(--radius-md);
-          padding: 1rem 1.25rem;
+          padding: 0.75rem 1rem;
           box-shadow: var(--shadow-sm);
           border-left: 4px solid rgba(47, 139, 255, 0.4);
           cursor: grab;
           transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .activity-card p {
+          line-height: 1.45;
         }
 
         .activity-card:active {
@@ -291,7 +295,7 @@ const server = http.createServer((req, res) => {
           justify-content: space-between;
           align-items: center;
           gap: 0.5rem;
-          margin-bottom: 0.75rem;
+          margin-bottom: 0.5rem;
         }
 
         .badge {
@@ -300,9 +304,9 @@ const server = http.createServer((req, res) => {
           justify-content: center;
           font-weight: 600;
           border-radius: 50%;
-          width: 2.25rem;
-          height: 2.25rem;
-          font-size: 1.1rem;
+          width: 2rem;
+          height: 2rem;
+          font-size: 1rem;
           background: rgba(90, 170, 255, 0.22);
           color: var(--grey-900);
           flex-shrink: 0;
@@ -339,13 +343,13 @@ const server = http.createServer((req, res) => {
         }
 
         .activity-description {
-          margin: 0 0 0.75rem;
+          margin: 0 0 0.5rem;
           color: var(--grey-700);
           font-size: 0.95rem;
         }
 
         .activity-material {
-          margin: 0 0 0.75rem;
+          margin: 0 0 0.5rem;
           font-size: 0.85rem;
           color: var(--grey-500);
           font-weight: 600;
@@ -353,7 +357,7 @@ const server = http.createServer((req, res) => {
         }
 
         .activity-duration {
-          margin: 0 0 1rem;
+          margin: 0 0 0.5rem;
           font-size: 0.85rem;
           color: var(--grey-500);
           font-weight: 600;
@@ -362,6 +366,7 @@ const server = http.createServer((req, res) => {
         .activity-actions {
           display: flex;
           justify-content: flex-end;
+          margin-top: 0.25rem;
         }
 
         .btn-tertiary {


### PR DESCRIPTION
## Summary
- réduit l'espacement vertical dans les listes d'activités de la vue semaine pour afficher davantage de cartes
- compresse le contenu des cartes d'activités (badges, marges et hauteur de ligne) afin de diminuer leur hauteur globale

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d3da495ff08321ad381eaac0e815ec