### PR TITLE
Déplace la durée des activités avant la description

### DIFF
--- a/index.js
+++ b/index.js
@@ -963,8 +963,8 @@ const server = http.createServer((req, res) => {
               ? '⏱ ' + activity.duration
               : '⏱ Temps à définir';
 
-            summary.appendChild(description);
             summary.appendChild(duration);
+            summary.appendChild(description);
 
             top.appendChild(badge);
             top.appendChild(summary);


### PR DESCRIPTION
## Summary
- place l'affichage de la durée avant la description pour qu'elle apparaisse entre l'icône et le texte d'activité

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d3ddbff28c83219662363aae1b033b