### PR TITLE
Update half-day slot labels

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -28,19 +28,19 @@
   var halfDaySlots = [
     {
       id: 'monday-am',
-      label: 'Demi-journée 1',
+      label: 'Lundi matin',
       timeLabel: 'matin',
       dayOffset: 0
     },
     {
       id: 'monday-pm',
-      label: 'Demi-journée 2',
+      label: 'Lundi après-midi',
       timeLabel: 'après-midi',
       dayOffset: 0
     },
     {
       id: 'tuesday-am',
-      label: 'Demi-journée 3',
+      label: 'Mardi matin',
       timeLabel: 'matin',
       dayOffset: 1
     }


### PR DESCRIPTION
## Summary
- replace the generic half-day labels with descriptive names for each time slot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d3f10973908321a677851151606d51