### PR TITLE
Supprimer la description des demi-journees

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -244,12 +244,7 @@
       slotTitle.className = 'slot-title';
       slotTitle.textContent = slot.label;
 
-      var slotSubtitle = document.createElement('span');
-      slotSubtitle.className = 'slot-subtitle';
-      slotSubtitle.textContent = formatSlotSubtitle(week, slot.id);
-
       slotInfo.appendChild(slotTitle);
-      slotInfo.appendChild(slotSubtitle);
 
       var slotAddButton = document.createElement('button');
       slotAddButton.type = 'button';
@@ -1025,18 +1020,6 @@
       month: 'long',
       year: 'numeric'
     });
-  }
-
-  function formatSlotSubtitle(week, slotId) {
-    var slot = halfDaySlotMap[slotId];
-    if (!slot) {
-      return '';
-    }
-    var dayLabel = formatSlotDayLabel(week.startDate, slot);
-    if (dayLabel) {
-      return dayLabel;
-    }
-    return slot.label || '';
   }
 
   function formatSlotDayLabel(weekStartDate, slot) {

--- a/public/styles/board.css
+++ b/public/styles/board.css
@@ -124,11 +124,6 @@
   color: var(--grey-900);
 }
 
-.slot-subtitle {
-  font-size: 0.85rem;
-  color: var(--grey-500);
-}
-
 .slot-activities {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- afficher uniquement le titre de chaque demi-journée sur le tableau
- supprimer le code et le style inutiles liés au sous-titre des demi-journées

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d3f1be9fb0832188595050e8d49538