### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "canvacours",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "canvacours",
-      "version": "1.3.0"
+      "version": "1.3.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvacours",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Basic Node.js application with a simple HTTP server.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the application version to 1.3.1 in package metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d3f1f84bbc8321bb7ccf19e5e8788d