### PR TITLE
Reorder description field in activity modal form

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -50,16 +50,16 @@
               </select>
             </div>
             <div class="form-group">
+              <label for="description">Description</label>
+              <textarea id="description" name="description" rows="4" placeholder="Décrivez le déroulement de l'activité" required></textarea>
+            </div>
+            <div class="form-group">
               <label for="duration">Temps prévu</label>
               <input id="duration" name="duration" type="text" placeholder="Ex. 2h, 45 minutes" />
             </div>
             <div class="form-group">
               <label for="material">Matériel</label>
               <input id="material" name="material" type="text" placeholder="Ex. diaporama_introduction.pdf" />
-            </div>
-            <div class="form-group">
-              <label for="description">Description</label>
-              <textarea id="description" name="description" rows="4" placeholder="Décrivez le déroulement de l'activité" required></textarea>
             </div>
             <div class="form-actions">
               <button type="submit" class="btn-primary">Enregistrer</button>


### PR DESCRIPTION
## Summary
- move the description textarea directly under the activity type selector so it appears immediately after the type field when creating or editing an activity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d3f28d670c8321a53f6654e0787c6c