### PR TITLE
Adapte les titres des demi-journées à la date de la semaine

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -242,7 +242,8 @@
 
       var slotTitle = document.createElement('span');
       slotTitle.className = 'slot-title';
-      slotTitle.textContent = slot.label;
+      var slotTitleText = formatSlotDayLabel(week.startDate, slot);
+      slotTitle.textContent = slotTitleText || slot.label;
 
       slotInfo.appendChild(slotTitle);
 
@@ -912,18 +913,15 @@
       return;
     }
     var dayLabel = formatSlotDayLabel(week.startDate, slot);
-    var helperParts = [];
     if (dayLabel) {
-      helperParts.push(dayLabel);
+      slotHelper.textContent = dayLabel;
+      return;
     }
-    if (slot.label && slot.label !== dayLabel) {
-      helperParts.push(slot.label);
+    if (slot.label) {
+      slotHelper.textContent = slot.label;
+      return;
     }
-    var helperLabel = helperParts.join(' · ');
-    if (!helperLabel) {
-      helperLabel = slotHelperDefaultText;
-    }
-    slotHelper.textContent = helperLabel;
+    slotHelper.textContent = slotHelperDefaultText;
   }
 
   function saveData() {


### PR DESCRIPTION
## Summary
- calcule le titre de chaque demi-journée à partir de la date de début de la semaine
- aligne l'aide du formulaire sur le nouveau libellé dynamique

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d3f2edec588321a9b2ee93ee23b0d9