### PR TITLE
Replace add button label with plus icon

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -253,7 +253,8 @@
       slotAddButton.setAttribute('data-action', 'add-activity');
       slotAddButton.setAttribute('data-week-id', week.id);
       slotAddButton.setAttribute('data-slot-id', slot.id);
-      slotAddButton.textContent = 'Ajouter';
+      slotAddButton.setAttribute('aria-label', 'Ajouter une activité');
+      slotAddButton.textContent = '+';
 
       slotHeader.appendChild(slotInfo);
       slotHeader.appendChild(slotAddButton);


### PR DESCRIPTION
## Summary
- replace the "Ajouter" label on the slot add button with a "+" icon
- add an aria-label to preserve accessible text for the button

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d3f5743494832193aa5f6147befe2c