### PR TITLE
Remove visible Cours label from course selector

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,6 @@
           </div>
           <div class="header-actions">
             <label class="course-selector" for="course-selector">
-              <span class="course-selector-label">Cours</span>
               <select id="course-selector" class="course-selector-input" aria-label="Sélection du cours"></select>
             </label>
             <button type="button" class="btn-secondary header-new-course" id="new-course-button">


### PR DESCRIPTION
## Summary
- remove the redundant "Cours" label displayed above the course selector dropdown

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d3f7ae91c8832186b3dc2a3e8da71f