### PR TITLE
Add course renaming support

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -82,6 +82,7 @@
   var modalCloseButtons = modal.querySelectorAll('[data-action="close-modal"]');
   var courseSelector = document.getElementById('course-selector');
   var newCourseButton = document.getElementById('new-course-button');
+  var renameCourseButton = document.getElementById('rename-course-button');
   var draggedActivityId = null;
   var coursesState = loadCoursesState();
   var courseData = getActiveCourseWeeks();
@@ -99,6 +100,12 @@
   if (newCourseButton) {
     newCourseButton.addEventListener('click', function () {
       createNewCourse();
+    });
+  }
+
+  if (renameCourseButton) {
+    renameCourseButton.addEventListener('click', function () {
+      renameActiveCourse();
     });
   }
 
@@ -956,6 +963,49 @@
     };
     coursesState.courses.push(newCourse);
     setActiveCourse(newCourse.id);
+  }
+
+  function renameActiveCourse() {
+    if (!coursesState || !Array.isArray(coursesState.courses)) {
+      return;
+    }
+    var activeCourse = getActiveCourse();
+    if (!activeCourse) {
+      return;
+    }
+    var currentName =
+      typeof activeCourse.name === 'string' && activeCourse.name.trim()
+        ? activeCourse.name.trim()
+        : generateDefaultCourseName(1);
+    var proposedName = window.prompt('Nom du cours', currentName);
+    if (typeof proposedName !== 'string') {
+      return;
+    }
+    var trimmed = proposedName.trim();
+    if (!trimmed) {
+      return;
+    }
+    var normalized = trimmed.toLowerCase();
+    var duplicate = coursesState.courses.some(function (course) {
+      if (!course || course.id === activeCourse.id) {
+        return false;
+      }
+      if (typeof course.name !== 'string') {
+        return false;
+      }
+      return course.name.trim().toLowerCase() === normalized;
+    });
+    if (duplicate) {
+      window.alert('Un cours avec ce nom existe déjà.');
+      return;
+    }
+    activeCourse.name = trimmed;
+    saveData();
+    updateCourseSelector();
+    if (courseSelector) {
+      courseSelector.value = activeCourse.id;
+      courseSelector.focus();
+    }
   }
 
   function loadCoursesState() {

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,9 @@
               <span class="course-selector-label">Cours</span>
               <select id="course-selector" class="course-selector-input" aria-label="Sélection du cours"></select>
             </label>
+            <button type="button" class="btn-secondary header-rename-course" id="rename-course-button">
+              Renommer le cours
+            </button>
             <button type="button" class="btn-secondary header-new-course" id="new-course-button">
               Nouveau cours
             </button>

--- a/public/styles/base.css
+++ b/public/styles/base.css
@@ -107,7 +107,8 @@ body.modal-open {
   box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.25);
 }
 
-.header-new-course {
+.header-new-course,
+.header-rename-course {
   white-space: nowrap;
 }
 

--- a/public/styles/responsive.css
+++ b/public/styles/responsive.css
@@ -15,7 +15,8 @@
     width: 100%;
   }
 
-  .header-new-course {
+  .header-new-course,
+  .header-rename-course {
     justify-content: center;
     width: 100%;
   }


### PR DESCRIPTION
## Summary
- add a dedicated button in the header to rename the active course
- update the front-end logic to prompt for a new course name, prevent duplicates, and persist the change
- align header styles so the new action behaves correctly on desktop and mobile layouts

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68d3f7bf8e9483219de6719e51fd0737