### PR TITLE
Update activity type list and styling

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -14,17 +14,43 @@
 
   var typeLabels = {
     presentation: 'Présentation',
-    exercice: 'Exercice',
-    evaluation: 'Évaluation',
-    groupe: 'Travail de groupe'
+    groupe: 'Travail de groupe',
+    demonstration: 'Démonstration',
+    'exercice-individuel': 'Exercice individuel',
+    recherche: "Recherche d'information",
+    jeu: 'Jeu/Tournoi/Challenge',
+    synthese: 'Synthèse',
+    evaluation: 'Évaluation'
   };
 
   var typeIcons = {
     presentation: '🎤',
-    exercice: '📝',
-    evaluation: '📊',
-    groupe: '🤝'
+    groupe: '🤝',
+    demonstration: '🧑‍🏫',
+    'exercice-individuel': '✍️',
+    recherche: '🔍',
+    jeu: '🏆',
+    synthese: '🧠',
+    evaluation: '📊'
   };
+
+  var typeAliases = {
+    exercice: 'exercice-individuel'
+  };
+
+  function normalizeActivityType(value) {
+    if (typeof value !== 'string') {
+      return 'presentation';
+    }
+    var key = value.trim().toLowerCase();
+    if (!key) {
+      return 'presentation';
+    }
+    if (typeAliases[key]) {
+      key = typeAliases[key];
+    }
+    return typeLabels[key] ? key : 'presentation';
+  }
 
   var halfDaySlots = [
     {
@@ -331,7 +357,7 @@
     top.className = 'activity-top';
 
     var badge = document.createElement('span');
-    var typeKey = activity.type && typeLabels[activity.type] ? activity.type : 'presentation';
+    var typeKey = normalizeActivityType(activity.type);
     var badgeLabel = typeLabels[typeKey] || 'Activité';
     var badgeIcon = typeIcons[typeKey] || '🎯';
     badge.className = 'badge badge-' + typeKey;
@@ -795,10 +821,7 @@
       formTitle.textContent = 'Modifier une activité';
       activityIdInput.value = options.activity.id;
       setSlotValue(options.activity.slot);
-      typeSelect.value =
-        options.activity.type && typeLabels[options.activity.type]
-          ? options.activity.type
-          : 'presentation';
+      typeSelect.value = normalizeActivityType(options.activity.type);
       durationInput.value = options.activity.duration || '';
       materialInput.value = options.activity.material || '';
       descriptionInput.value = options.activity.description || '';
@@ -1260,7 +1283,7 @@
     if (!activity || typeof activity !== 'object') {
       return null;
     }
-    var type = activity.type && typeLabels[activity.type] ? activity.type : 'presentation';
+    var type = normalizeActivityType(activity.type);
     var slotId = normalizeSlotId(activity.slot);
     var normalizedWeekStart = normalizeWeekStartDate(weekStartDate);
     var sanitizedDate = '';

--- a/public/index.html
+++ b/public/index.html
@@ -49,9 +49,13 @@
               <label for="activity-type">Type d'activité</label>
               <select id="activity-type" name="activityType" required>
                 <option value="presentation">🎤 Présentation</option>
-                <option value="exercice">📝 Exercice</option>
-                <option value="evaluation">📊 Évaluation</option>
                 <option value="groupe">🤝 Travail de groupe</option>
+                <option value="demonstration">🧑‍🏫 Démonstration</option>
+                <option value="exercice-individuel">✍️ Exercice individuel</option>
+                <option value="recherche">🔍 Recherche d'information</option>
+                <option value="jeu">🏆 Jeu/Tournoi/Challenge</option>
+                <option value="synthese">🧠 Synthèse</option>
+                <option value="evaluation">📊 Évaluation</option>
               </select>
             </div>
             <div class="form-group">

--- a/public/styles/activity.css
+++ b/public/styles/activity.css
@@ -78,19 +78,40 @@
   color: #17507e;
 }
 
-.badge-exercice {
-  background: rgba(82, 168, 236, 0.25);
-  color: #184c72;
+.badge-groupe {
+  background: rgba(54, 136, 199, 0.25);
+  color: #123651;
+}
+
+.badge-demonstration {
+  background: rgba(255, 206, 160, 0.25);
+  color: #7a4310;
+}
+
+.badge-exercice,
+.badge-exercice-individuel {
+  background: rgba(156, 224, 178, 0.25);
+  color: #1f5f36;
+}
+
+.badge-recherche {
+  background: rgba(152, 196, 255, 0.25);
+  color: #1b4670;
+}
+
+.badge-jeu {
+  background: rgba(255, 212, 153, 0.25);
+  color: #7a4d0b;
+}
+
+.badge-synthese {
+  background: rgba(204, 186, 255, 0.25);
+  color: #4a2f87;
 }
 
 .badge-evaluation {
   background: rgba(66, 150, 214, 0.25);
   color: #153f61;
-}
-
-.badge-groupe {
-  background: rgba(54, 136, 199, 0.25);
-  color: #123651;
 }
 
 .activity-description {


### PR DESCRIPTION
## Summary
- replace the activity type list with the new eight-category set and display matching icons in the form
- normalize stored activity types to the new identifiers so existing "Exercice" entries keep working
- refresh badge styling to cover the new activity types and retain a fallback for historical data

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68d3fb39c0188321b32e55915b13822d