### PR TITLE
Use icons for header course actions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,11 +22,23 @@
             <label class="course-selector" for="course-selector">
               <select id="course-selector" class="course-selector-input" aria-label="Sélection du cours"></select>
             </label>
-            <button type="button" class="btn-secondary header-rename-course" id="rename-course-button">
-              Renommer le cours
+            <button
+              type="button"
+              class="btn-secondary header-rename-course header-icon-button"
+              id="rename-course-button"
+              aria-label="Renommer le cours"
+              title="Renommer le cours"
+            >
+              <span aria-hidden="true">✏️</span>
             </button>
-            <button type="button" class="btn-secondary header-new-course" id="new-course-button">
-              Nouveau cours
+            <button
+              type="button"
+              class="btn-secondary header-new-course header-icon-button"
+              id="new-course-button"
+              aria-label="Ajouter un cours"
+              title="Ajouter un cours"
+            >
+              <span aria-hidden="true">➕</span>
             </button>
           </div>
         </div>

--- a/public/styles/buttons.css
+++ b/public/styles/buttons.css
@@ -80,3 +80,20 @@
 .btn-secondary:active {
   transform: translateY(1px);
 }
+
+.header-icon-button {
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.header-icon-button span[aria-hidden='true'] {
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- replace the header rename and add course button labels with dedicated icons
- add styling for the new header icon buttons so they display as circular controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d3fca23c888321811ebec672807752