### PR TITLE
Add week start half-day selection

### DIFF
--- a/public/styles/board.css
+++ b/public/styles/board.css
@@ -81,6 +81,52 @@
   box-shadow: 0 0 0 3px rgba(47, 139, 255, 0.25);
 }
 
+.week-halfday-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+}
+
+.week-halfday-toggle-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--grey-500);
+}
+
+.week-halfday-toggle-options {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(47, 139, 255, 0.35);
+  background: rgba(247, 251, 255, 0.9);
+}
+
+.week-halfday-toggle-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--grey-500);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.week-halfday-toggle-option input {
+  margin: 0;
+  accent-color: var(--blue-500);
+}
+
+.week-halfday-toggle-option.is-active {
+  background: rgba(47, 139, 255, 0.14);
+  color: var(--blue-500);
+  font-weight: 600;
+}
+
 .week-slots {
   padding: 1.25rem;
   display: flex;
@@ -105,6 +151,15 @@
   box-shadow: 0 0 0 3px rgba(47, 139, 255, 0.18);
 }
 
+.slot-section.slot-start {
+  border-color: rgba(47, 139, 255, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(47, 139, 255, 0.12);
+}
+
+.slot-section.slot-start .slot-title {
+  color: var(--blue-600);
+}
+
 .slot-header {
   display: flex;
   align-items: center;
@@ -122,6 +177,19 @@
   font-weight: 700;
   font-size: 1rem;
   color: var(--grey-900);
+}
+
+.slot-start-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(47, 139, 255, 0.16);
+  color: var(--blue-500);
+  border-radius: 999px;
 }
 
 .slot-activities {


### PR DESCRIPTION
## Summary
- add a per-week toggle to choose the starting half-day (matin/après-midi)
- persist and normalize the choice in the stored course data
- highlight the beginning slot in the agenda and expose helper text updates with new styles

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68d40daf8c888321ad892fe6d9e9204a