### PR TITLE
Ensure afternoon start displays the correct first half-day

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -373,7 +373,8 @@
 
     var startSlotId = getWeekStartSlotId(week);
 
-    halfDaySlots.forEach(function (slot) {
+    var orderedSlots = getOrderedHalfDaySlotsForWeek(week);
+    orderedSlots.forEach(function (slot) {
       var slotSection = document.createElement('section');
       slotSection.className = 'slot-section';
       slotSection.setAttribute('data-week-id', week.id);
@@ -1742,6 +1743,24 @@
       return candidate;
     }
     return defaultSlotId;
+  }
+
+  function getOrderedHalfDaySlotsForWeek(week) {
+    var startSlotId = getWeekStartSlotId(week);
+    var baseSlots = halfDaySlots.slice();
+    var startIndex = baseSlots.findIndex(function (slot) {
+      return slot.id === startSlotId;
+    });
+    if (startIndex <= 0) {
+      return baseSlots;
+    }
+    var orderedSlots = [baseSlots[startIndex]];
+    baseSlots.forEach(function (slot, index) {
+      if (index !== startIndex) {
+        orderedSlots.push(slot);
+      }
+    });
+    return orderedSlots;
   }
 
   function countSlotActivitiesForWeek(weekId, slotId) {


### PR DESCRIPTION
## Summary
- reorder the half-day sections rendered for a week so the selected start moment appears first
- add a helper that keeps the remaining half-days in their original order after the start slot

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_b_68d411a854548321894cfc6e5e5d4fac