### PR TITLE
Clarify half-day helper text

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -103,7 +103,7 @@
   };
 
   var slotHelperDefaultText =
-    "La demi-journée est déterminée automatiquement en fonction du créneau depuis lequel vous ajoutez l'activité.";
+    "Les activités restent toujours dans la même demie-journée, c'est uniquement son nom qui change.";
 
   var board = document.getElementById('weeks-board');
   var modal = document.getElementById('activity-modal');

--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,7 @@
                 <legend>Moment</legend>
                 <div class="slot-radio-group" id="slot-radio-group" role="radiogroup" aria-label="Sélection du moment de la journée"></div>
                 <p id="slot-helper" class="form-helper">
-                  La demi-journée est déterminée automatiquement en fonction du créneau depuis lequel vous ajoutez l'activité.
+                  Les activités restent toujours dans la même demie-journée, c'est uniquement son nom qui change.
                 </p>
               </fieldset>
             </div>


### PR DESCRIPTION
## Summary
- update the helper message in the activity modal to explain that only the half-day name changes
- align the JavaScript default helper text with the HTML copy

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d41abf0d148321970696d6355500f2