### PR TITLE
Propagate subsequent week dates after start change

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -318,6 +318,7 @@
       week.startDate = normalized;
       event.target.value = normalized;
       refreshWeekActivitiesDates(week);
+      propagateFollowingWeekStartDates(week);
       saveData();
       renderBoard();
       updateSlotHelper();
@@ -1677,6 +1678,50 @@
     courseData.forEach(function (week) {
       refreshWeekActivitiesDates(week);
     });
+  }
+
+  function propagateFollowingWeekStartDates(changedWeek) {
+    if (!changedWeek || !Array.isArray(courseData)) {
+      return;
+    }
+    var startIndex = courseData.findIndex(function (week) {
+      if (!week || typeof week !== 'object') {
+        return false;
+      }
+      if (week === changedWeek) {
+        return true;
+      }
+      if (changedWeek && week.id && changedWeek.id) {
+        return week.id === changedWeek.id;
+      }
+      return false;
+    });
+    if (startIndex === -1) {
+      return;
+    }
+    var previousStart = normalizeWeekStartDate(courseData[startIndex].startDate);
+    for (var index = startIndex + 1; index < courseData.length; index += 1) {
+      var targetWeek = courseData[index];
+      if (!targetWeek || typeof targetWeek !== 'object') {
+        continue;
+      }
+      if (previousStart) {
+        var previousDate = new Date(previousStart + 'T00:00:00');
+        if (isNaN(previousDate.getTime())) {
+          targetWeek.startDate = '';
+          previousStart = '';
+        } else {
+          previousDate.setDate(previousDate.getDate() + 7);
+          var formatted = formatDateForInput(previousDate);
+          targetWeek.startDate = formatted;
+          previousStart = formatted;
+        }
+      } else {
+        targetWeek.startDate = '';
+        previousStart = '';
+      }
+      refreshWeekActivitiesDates(targetWeek);
+    }
   }
 
   function refreshWeekActivitiesDates(week) {


### PR DESCRIPTION
## Summary
- propagate start dates to subsequent weeks whenever a week start date is changed
- refresh downstream activities to keep their computed dates in sync with the new schedule

## Testing
- No automated tests available


------
https://chatgpt.com/codex/tasks/task_b_68d42604ce8c8321b90c6fcbeccebc12