### PR TITLE
Add date to half-day slot titles

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -403,7 +403,12 @@
       var slotTitle = document.createElement('span');
       slotTitle.className = 'slot-title';
       var slotTitleText = formatSlotDayLabel(week.startDate, slot);
-      slotTitle.textContent = slotTitleText || slot.label;
+      var slotDateText = formatSlotDateLabel(week.startDate, slot);
+      var slotDisplayText = slotTitleText || slot.label;
+      if (slotDateText) {
+        slotDisplayText += ' – ' + slotDateText;
+      }
+      slotTitle.textContent = slotDisplayText;
 
       slotInfo.appendChild(slotTitle);
 
@@ -1761,6 +1766,25 @@
       return formattedDay + ' ' + slot.timeLabel;
     }
     return formattedDay;
+  }
+
+  function formatSlotDateLabel(weekStartDate, slot) {
+    if (!slot) {
+      return '';
+    }
+    var slotDate = computeSlotDate(weekStartDate, slot.id);
+    if (!slotDate) {
+      return '';
+    }
+    var parsedDate = new Date(slotDate + 'T00:00:00');
+    if (isNaN(parsedDate.getTime())) {
+      return '';
+    }
+    return parsedDate.toLocaleDateString('fr-FR', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    });
   }
 
   function capitalizeFirstLetter(value) {


### PR DESCRIPTION
## Summary
- add formatted slot dates next to each half-day title in the week view
- introduce a helper to compute localized date labels for half-day slots

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68d42830193c832192bdbb43bfad941f