### PR TITLE
Remove week and moment sections from activity form

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -66,19 +66,6 @@
             <input type="hidden" name="activityId" id="activity-id" />
             <input type="hidden" name="weekId" id="week-id" value="" />
             <input type="hidden" name="slot" id="slot" value="" />
-            <div class="form-row">
-              <div class="form-group form-group-inline">
-                <label for="week-select">Semaine</label>
-                <select id="week-select" name="weekSelect" aria-label="Sélection de la semaine"></select>
-              </div>
-              <fieldset class="form-group form-group-inline form-group-slot">
-                <legend>Moment</legend>
-                <div class="slot-radio-group" id="slot-radio-group" role="radiogroup" aria-label="Sélection du moment de la journée"></div>
-                <p id="slot-helper" class="form-helper">
-                  Les activités restent toujours dans la même demie-journée, c'est uniquement son nom qui change.
-                </p>
-              </fieldset>
-            </div>
             <div class="form-group">
               <label for="activity-type">Type d'activité</label>
               <select id="activity-type" name="activityType" required>


### PR DESCRIPTION
## Summary
- remove the week dropdown and moment radio group from the activity form markup since they are no longer needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d42ae8b8c083218d659300046088ae