### PR TITLE
Ensure half-day changes propagate to subsequent weeks

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -361,6 +361,7 @@
         var previousOrder = getActivitySlotOrderIndices(week.activities);
         week.startHalfDay = selectedValue;
         remapWeekActivitiesForHalfDay(week, previousOrder);
+        propagateFollowingWeekStartDates(week);
         saveData();
         renderBoard();
         updateSlotHelper();


### PR DESCRIPTION
## Summary
- propagate the selected start half-day to the following weeks when toggling the half-day option
- keep subsequent weeks' activities in sync after the propagated half-day update

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d42c14ebe883219fd7eb23e72ab4a3