### PR TITLE
Load environment variables from .env when available

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,31 @@
+const fs = require('fs');
 const path = require('path');
+
+const envFilePath = path.join(__dirname, '..', '.env');
+if (fs.existsSync(envFilePath)) {
+  const envContent = fs.readFileSync(envFilePath, 'utf8');
+  envContent.split(/\r?\n/).forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      return;
+    }
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex === -1) {
+      return;
+    }
+    const key = trimmed.slice(0, separatorIndex).trim();
+    if (!key) {
+      return;
+    }
+    let value = trimmed.slice(separatorIndex + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  });
+}
 
 const { version } = require('../package.json');
 


### PR DESCRIPTION
## Summary
- load variables from the repository .env file when the file exists
- implement lightweight parser to populate process.env without external dependencies

## Testing
- node -e "require('./src/config'); console.log('config loaded');"


------
https://chatgpt.com/codex/tasks/task_b_68d432ced14083219fe894a8ac8d44b2