### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "canvacours",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "canvacours",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "dependencies": {
         "express": "^4.19.2",
         "mariadb": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvacours",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Basic Node.js application with a simple HTTP server.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the package version from 1.5.0 to 2.0.0 in package.json and package-lock.json

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4348bd3e083219c215db432716b53