### PR TITLE
Fix version placeholder rendering in footer

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,14 @@
 'use strict';
 
+const fs = require('fs');
 const express = require('express');
-const { INDEX_FILE, PORT, PUBLIC_DIR } = require('./config');
+const { APP_VERSION, INDEX_FILE, PORT, PUBLIC_DIR } = require('./config');
 const { initializeDatabase } = require('./database');
 const apiRouter = require('./routes/api');
+
+const indexHtml = fs
+  .readFileSync(INDEX_FILE, 'utf8')
+  .replace(/%%APP_VERSION%%/g, APP_VERSION || '');
 
 function createApp() {
   const app = express();
@@ -18,7 +23,7 @@ function createApp() {
   }));
 
   app.get('*', (req, res) => {
-    res.sendFile(INDEX_FILE);
+    res.type('html').send(indexHtml);
   });
 
   app.use((err, req, res, next) => {


### PR DESCRIPTION
## Summary
- load the main HTML template at startup and inject the application version from package.json
- serve the cached HTML in the catch-all route so the footer shows the real version string

## Testing
- node -e 'const { createApp } = require("./src/server"); const app = createApp(); if (!app) { throw new Error("app not created"); } console.log("app ready");' *(fails: missing express dependency because npm install is blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68d43557c1708321b823e7117d107f42