### PR TITLE
Fix footer version placeholder rendering

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,10 @@ const indexHtml = fs
   .readFileSync(INDEX_FILE, 'utf8')
   .replace(/%%APP_VERSION%%/g, APP_VERSION || '');
 
+function sendIndexHtml(res) {
+  res.type('html').send(indexHtml);
+}
+
 function createApp() {
   const app = express();
 
@@ -17,13 +21,17 @@ function createApp() {
 
   app.use('/api', apiRouter);
 
+  app.get(['/', '/index.html'], (req, res) => {
+    sendIndexHtml(res);
+  });
+
   app.use(express.static(PUBLIC_DIR, {
     fallthrough: true,
     extensions: ['html']
   }));
 
   app.get('*', (req, res) => {
-    res.type('html').send(indexHtml);
+    sendIndexHtml(res);
   });
 
   app.use((err, req, res, next) => {


### PR DESCRIPTION
## Summary
- ensure the Express server responds with the processed index.html for root requests
- reuse a helper to send the HTML with the resolved application version placeholder

## Testing
- not run (npm install fails: registry access forbidden)


------
https://chatgpt.com/codex/tasks/task_b_68d4361ba1448321b9cd9c89417ad384